### PR TITLE
allow string concat in like

### DIFF
--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -2191,7 +2191,7 @@ regexp_op_right
   }
 
 like_op_right
-  = op:like_op __ right:(literal / comparison_expr ) __ es:escape_op? {
+  = op:like_op __ right:(comparison_expr / literal) __ es:escape_op? {
       if (es) right.escape = es
       return { op: op, right: right };
     }

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -253,4 +253,8 @@ describe('sqlite', () => {
     const sql = `SELECT * FROM table_name WHERE column_name LIKE '\\_%' ESCAPE '\\'`
     expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '\\_%' ESCAPE '\\'`)
   })
+  it('should support string concatenation in LIKE opts', () => {
+    const sql = `SELECT * FROM file WHERE path LIKE 'C:' || CHAR(92) || 'Users' || CHAR(92) || 'example.txt'`
+    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "file" WHERE "path" LIKE 'C:' || CHAR(92) || 'Users' || CHAR(92) || 'example.txt'`)
+  })
 })


### PR DESCRIPTION
Switches the order of precedence in the like op so that it checks for `comaprison_expr` before `literal`, so that it if a string concatenation like

```sql
SELECT * FROM file WHERE path LIKE 'C:' || CHAR(92) || 'Users' || CHAR(92) || 'example.txt';
```

is present, it grabs the whole thing instead of just stopping at `'C:'` and leaving an unparsed `|| CHAR(92) || 'Users' || CHAR(92) || 'example.txt';` at the end of the query causing a syntax error.
