### PR TITLE
Update reserved words list, add more join support

### DIFF
--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -61,74 +61,74 @@
   };
 
   const invalidImplicitAliasMap = {
-    'INDEXED': true,
-    'INDEX': true,
-    'ESCAPE': true,
-    'CHECK': true,
-    'FOREIGN': true,
-    'REGEXP': true,
     'ADD': true,
-    'AS': true,
-    'SELECT': true,
-    'TABLE': true,
-    'LEFT': true,
-    'THEN': true,
-    'DEFERRABLE': true,
-    'ELSE': true,
-    'DELETE': true,
-    'OR': true,
-    'INTERSECT': true,
-    'NOT': true,
-    'NULL': true,
-    'LIKE': true,
-    'EXCEPT': true,
-    'TRANSACTION': true,
-    'ON': true,
-    'NATURAL': true,
+    'ALL': true,
     'ALTER': true,
-    'EXISTS': true,
-    'CONSTRAINT': true,
-    'INTO': true,
-    'SET': true,
-    'HAVING': true,
-    'GLOB': true,
-    'INNER': true,
-    'REFERENCES': true,
-    'UNIQUE': true,
-    'OUTER': true,
+    'AND': true,
+    'AS': true,
+    'AUTOINCREMENT': true,
     'BETWEEN': true,
-    'NOTHING': true,
-    'GROUP': true,
-    'DEFAULT': true,
     'CASE': true,
+    'CHECK': true,
     'COLLATE': true,
+    'COMMIT': true,
+    'CONSTRAINT': true,
     'CREATE': true,
-    'JOIN': true,
-    'INSERT': true,
-    'MATCH': true,
+    'CROSS': true,
+    'DEFAULT': true,
+    'DEFERRABLE': true,
+    'DELETE': true,
     'DISTINCT': true,
+    'DROP': true,
+    'ELSE': true,
+    'ESCAPE': true,
+    'EXCEPT': true,
+    'EXISTS': true,
+    'FOREIGN': true,
+    'FROM': true,
+    'FULL': true,
+    'GLOB': true,
+    'GROUP': true,
+    'HAVING': true,
+    'IN': true,
+    'INDEX': true,
+    'INDEXED': true,
+    'INNER': true,
+    'INSERT': true,
+    'INTERSECT': true,
+    'INTO': true,
     'IS': true,
+    'JOIN': true,
+    'LEFT': true,
+    'LIKE': true,
+    'LIMIT': true,
+    'MATCH': true,
+    'NATURAL': true,
+    'NOT': true,
+    'NOTHING': true,
+    'NULL': true,
+    'ON': true,
+    'OR': true,
+    'ORDER': true,
+    'OUTER': true,
+    'PRIMARY': true,
+    'REFERENCES': true,
+    'REGEXP': true,
+    'RETURNING': true,
+    'RIGHT': true,
+    'SELECT': true,
+    'SET': true,
+    'TABLE': true,
+    'THEN': true,
+    'TO': true,
+    'TRANSACTION': true,
+    'UNION': true,
+    'UNIQUE': true,
     'UPDATE': true,
+    'USING': true,
     'VALUES': true,
     'WHEN': true,
     'WHERE': true,
-    'AND': true,
-    'DROP': true,
-    'AUTOINCREMENT': true,
-    'TO': true,
-    'IN': true,
-    'COMMIT': true,
-    'CROSS': true,
-    'FROM': true,
-    'FULL': true,
-    'LIMIT': true,
-    'ORDER': true,
-    'RETURNING': true,
-    'RIGHT': true,
-    'UNION': true,
-    'USING': true,
-    'ALL': true,
-    'PRIMARY': true
   }
 
   function getLocationObject() {
@@ -1681,8 +1681,11 @@ table_base
     }
 
 join_op
-  = KW_LEFT __ KW_OUTER? __ KW_JOIN { return 'LEFT JOIN'; }
-  / (KW_INNER __)? KW_JOIN { return 'INNER JOIN'; }
+  = natural:(KW_NATURAL __)? KW_LEFT __ KW_OUTER? __ KW_JOIN { return natural ? 'NATURAL LEFT JOIN' : 'LEFT JOIN'; }
+  / natural:(KW_NATURAL __)? KW_RIGHT __ KW_OUTER? __ KW_JOIN { return natural ? 'NATURAL RIGHT JOIN' : 'RIGHT JOIN'; }
+  / natural:(KW_NATURAL __)? KW_FULL __ KW_OUTER? __ KW_JOIN { return natural ? 'NATURAL FULL JOIN' : 'FULL JOIN'; }
+  / natural:(KW_NATURAL __)? (KW_INNER __)? KW_JOIN { return natural ? 'NATURAL INNER JOIN' : 'INNER JOIN'; }
+  / KW_CROSS __ KW_JOIN { return 'CROSS JOIN'; }
 
 table_name
   = dt:ident tail:(__ DOT __ ident)? {
@@ -2817,7 +2820,11 @@ KW_COLLATE  = "COLLATE"i    !ident_start { return 'COLLATE'; }
 
 KW_ON       = "ON"i       !ident_start
 KW_LEFT     = "LEFT"i     !ident_start
+KW_RIGHT    = "RIGHT"i     !ident_start
+KW_CROSS    = "CROSS"i      !ident_start
+KW_FULL     = "FULL"i     !ident_start
 KW_INNER    = "INNER"i    !ident_start
+KW_NATURAL  = "NATURAL"i     !ident_start
 KW_JOIN     = "JOIN"i     !ident_start
 KW_OUTER    = "OUTER"i    !ident_start
 KW_OVER     = "OVER"i     !ident_start

--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -2655,26 +2655,11 @@ single_quote_char
   / escape_char
 
 single_char
-  = [^'\\] // remove \0-\x1F\x7f pnCtrl char [^'\\\0-\x1F\x7f]
+  = [^'] // remove \0-\x1F\x7f pnCtrl char [^'\\\0-\x1F\x7f]
   / escape_char
 
 escape_char
-  = "\\'"  { return "\\'";  }
-  / '\\"'  { return '\\"';  }
-  / "\\\\" { return "\\\\"; }
-  / "\\/"  { return "\\/";  }
-  / "\\b"  { return "\b"; }
-  / "\\f"  { return "\f"; }
-  / "\\n"  { return "\n"; }
-  / "\\r"  { return "\r"; }
-  / "\\t"  { return "\t"; }
-  / "\\u" h1:hexDigit h2:hexDigit h3:hexDigit h4:hexDigit {
-      return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
-    }
-  / "\\" { return "\\"; }
-  / "''" { return "''" }
-  / '""' { return '""' }
-  / '``' { return '``' }
+  = "''"
 
 line_terminator
   = [\n\r]

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -266,8 +266,12 @@ describe('sqlite', () => {
     })
   })
   it('should support LIKE with ESCAPE', () => {
-    const sql = `SELECT * FROM table_name WHERE column_name LIKE '%pattern%' ESCAPE '\'`
-    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '%pattern%' ESCAPE '\'`)
+    const sql = `SELECT * FROM table_name WHERE column_name LIKE '%pattern%' ESCAPE 'x'`
+    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '%pattern%' ESCAPE 'x'`)
+  })
+  it('should allow single backslash without escaping', () => {
+    const sql = `SELECT * FROM table_name WHERE column_name LIKE '\\_%' ESCAPE '\\'`
+    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '\\_%' ESCAPE '\\'`)
   })
   it('should support string concatenation in LIKE opts', () => {
     const sql = `SELECT * FROM file WHERE path LIKE 'C:' || CHAR(92) || 'Users' || CHAR(92) || 'example.txt'`

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -300,4 +300,20 @@ describe('sqlite', () => {
         expect(getParsedSql(sql)).to.be.equal(sql)
       });
   });
+  it('should allow column names that are keywords, but not reserved words, without quotes', () => {
+    const sql = `SELECT partition FROM some_table`
+    expect(getParsedSql(sql)).to.be.equal('SELECT "partition" FROM "some_table"')
+  })
+  it('should allow column names that are reserved words with quotes', () => {
+    const sql = `SELECT "from" FROM some_table`
+    expect(getParsedSql(sql)).to.be.equal('SELECT "from" FROM "some_table"')
+  })
+  it('should allow table names that are keywords, but not reserved words, without quotes', () => {
+    const sql = `CREATE TABLE partition (foo integer)`
+    expect(getParsedSql(sql)).to.be.equal('CREATE TABLE "partition" ("foo" INTEGER)')
+  })
+  it('should allow explict aliases that would be invalid as implicit aliases', () => {
+    const sql = `SELECT * FROM foo as left where left.bar=1`
+    expect(getParsedSql(sql)).to.be.equal('SELECT * FROM "foo" AS "left" WHERE "left"."bar" = 1')
+  })
 })

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -316,4 +316,31 @@ describe('sqlite', () => {
     const sql = `SELECT * FROM foo as left where left.bar=1`
     expect(getParsedSql(sql)).to.be.equal('SELECT * FROM "foo" AS "left" WHERE "left"."bar" = 1')
   })
+
+  describe('joins', () => {
+    const joinTypes = {
+      'LEFT JOIN': 'LEFT JOIN',
+      'LEFT OUTER JOIN': 'LEFT JOIN',
+      'RIGHT JOIN': 'RIGHT JOIN',
+      'RIGHT OUTER JOIN': 'RIGHT JOIN',
+      'FULL JOIN': 'FULL JOIN',
+      'FULL OUTER JOIN': 'FULL JOIN',
+      'INNER JOIN': 'INNER JOIN',
+      'NATURAL LEFT JOIN': 'NATURAL LEFT JOIN',
+      'NATURAL RIGHT JOIN': 'NATURAL RIGHT JOIN',
+      'NATURAL FULL JOIN': 'NATURAL FULL JOIN',
+      'NATURAL INNER JOIN': 'NATURAL INNER JOIN',
+      'NATURAL LEFT OUTER JOIN': 'NATURAL LEFT JOIN',
+      'NATURAL RIGHT OUTER JOIN': 'NATURAL RIGHT JOIN',
+      'NATURAL FULL OUTER JOIN': 'NATURAL FULL JOIN',
+      'CROSS JOIN': 'CROSS JOIN',
+      'JOIN': 'INNER JOIN',
+    }
+    Object.keys(joinTypes).forEach(joinType => {
+      it(`should support ${joinType}`, () => {
+        const sql = `SELECT * FROM table1 ${joinType} table2 ON table1.id = table2.t1_id`
+        expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table1" ${joinTypes[joinType]} "table2" ON "table1"."id" = "table2"."t1_id"`)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR updates the list of reserved words that cannot be used unquoted as identifiers. The list was generated using a C program that iterates over the full set of keywords in SQLite and attempts to do `CREATE TABLE t(<keyword> INTEGER);` for each one, tracking which keywords fail. Many words that were previously in the `reservedMap` passed this test and have been removed. 

Removing items from that list prompted a bit of yak shaving:

* The `alias_ident` rule has been split into `alias_ident_explicit` (i.e. using `AS`) and `alias_ident_implicit` (not using `AS`, e.g. `SELECT * FROM foo bar WHERE bar.val = 1`). 
* A new `invalidImplicitAliasMap` is added (generated using the same C program) to track which keywords cannot be used as implicit aliases. There's a lot of overlap with `reserveredMap`, but there are items exclusive to both lists.
* More joins have been implemented.  RIGHT joins were previously incorrectly parsed as aliases because the `join_op` rule didn't implement them, but now they were broken entirely, so I went ahead and implemented them + other missing joins.
* Added tests for all joins
* The `alter_table_stmt` rule now only supports one table name (which is correct for SQLite), as the previous rule was not compatible with the alias rule updates. That rule used `table_ref_list` which supports aliases for table names, which caused the parser to interpret things like `RENAME` as table aliases. Aliases are not valid in `ALTER TABLE` statements.