### PR TITLE
fix: update escape character for sqlite

### DIFF
--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -2655,26 +2655,11 @@ single_quote_char
   / escape_char
 
 single_char
-  = [^'\\] // remove \0-\x1F\x7f pnCtrl char [^'\\\0-\x1F\x7f]
+  = [^'] // remove \0-\x1F\x7f pnCtrl char [^'\\\0-\x1F\x7f]
   / escape_char
 
 escape_char
-  = "\\'"  { return "\\'";  }
-  / '\\"'  { return '\\"';  }
-  / "\\\\" { return "\\\\"; }
-  / "\\/"  { return "\\/";  }
-  / "\\b"  { return "\b"; }
-  / "\\f"  { return "\f"; }
-  / "\\n"  { return "\n"; }
-  / "\\r"  { return "\r"; }
-  / "\\t"  { return "\t"; }
-  / "\\u" h1:hexDigit h2:hexDigit h3:hexDigit h4:hexDigit {
-      return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
-    }
-  / "\\" { return "\\"; }
-  / "''" { return "''" }
-  / '""' { return '""' }
-  / '``' { return '``' }
+  = "''"
 
 line_terminator
   = [\n\r]

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -266,8 +266,12 @@ describe('sqlite', () => {
     })
   })
   it('should support LIKE with ESCAPE', () => {
-    const sql = `SELECT * FROM table_name WHERE column_name LIKE '%pattern%' ESCAPE '\'`
-    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '%pattern%' ESCAPE '\'`)
+    const sql = `SELECT * FROM table_name WHERE column_name LIKE '%pattern%' ESCAPE 'x'`
+    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '%pattern%' ESCAPE 'x'`)
+  })
+  it('should allow single backslash without escaping', () => {
+    const sql = `SELECT * FROM table_name WHERE column_name LIKE '\\_%' ESCAPE '\\'`
+    expect(getParsedSql(sql)).to.be.equal(`SELECT * FROM "table_name" WHERE "column_name" LIKE '\\_%' ESCAPE '\\'`)
   })
   it('should support string concatenation in LIKE opts', () => {
     const sql = `SELECT * FROM file WHERE path LIKE 'C:' || CHAR(92) || 'Users' || CHAR(92) || 'example.txt'`


### PR DESCRIPTION
fixes https://github.com/fleetdm/fleet/pull/31222

This PR updates the escape character sequences in SQLite to only be `''`.  From [the SQLite docs](https://www.sqlite.org/lang_expr.html) (see section 3 "Literal Values (Constants)"; emphasis mine):

> A string constant is formed by enclosing the string in single quotes ('). A single quote within the string can be encoded by putting two single quotes in a row - as in Pascal. _C-style escapes using the backslash character are not supported because they are not standard SQL_.

This fix allows the following common query pattern to work:

```
SELECT * FROM "table_name" WHERE "column_name" LIKE '\_%' ESCAPE '\'
```

This sets the escape character to a backslash so that single-character wildcared `_` char can be escaped, and you can look for values starting with an underscore. 

