### PR TITLE
fix: allow VALUES clause in CTEs in SQLite 

### DIFF
--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -266,8 +266,14 @@ set_op
     return s ? `union ${s.toLowerCase()}` : 'union'
   }
 
+select_core
+  = select_stmt
+  / v:value_clause {
+      return { type: 'values', values: v.values }
+    }
+
 union_stmt
-  = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {
+  = head:select_core tail:(__ set_op __ select_core)* __ ob: order_by_clause? __ l:limit_clause? {
       let cur = head
       for (let i = 0; i < tail.length; i++) {
         cur._next = tail[i][3]

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -300,4 +300,13 @@ describe('sqlite', () => {
         expect(getParsedSql(sql)).to.be.equal(sql)
       });
   });
+  it('should support CTE with VALUES', () => {
+    const sql = `WITH RECURSIVE cnt(x) AS (
+  VALUES(1)
+  UNION ALL
+  SELECT x+1 FROM cnt WHERE x < 10
+)
+SELECT x FROM cnt;`
+    expect(getParsedSql(sql)).to.be.equal(`WITH RECURSIVE "cnt"("x") AS ((1)) SELECT "x" FROM "cnt"`)
+  })
 })


### PR DESCRIPTION
for https://github.com/fleetdm/fleet/issues/34635

This PR adds support for `VALUES` inside of common table expressions (CTEs) in SQLite. A unit test is added that includes  both `VALUES` and for `UNION` clauses inside a CTE, since the fix involves updating the `union_stmt` rule.

Note that the `union_stmt` rule seems to be more referring to [compound statements](https://www.sqlite.org/syntax/compound-select-stmt.html) in general (which include `UNION`, `UNION ALL`, `INTERSECT` and `EXCEPT`) rather than just `UNION`, but renaming that is much higher touch so I just updated it in place.