### PR TITLE
fix: Allow strings without parentheses in IN clauses

### DIFF
--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -2227,7 +2227,7 @@ in_op_right
   = op:in_op __ LPAREN  __ l:expr_list __ RPAREN {
       return { op: op, right: l };
     }
-  / op:in_op __ e:(var_decl / literal_string / func_call) {
+  / op:in_op __ e:(var_decl / literal_string / column_ref / func_call) {
       return { op: op, right: e };
     }
 

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -300,4 +300,8 @@ describe('sqlite', () => {
         expect(getParsedSql(sql)).to.be.equal(sql)
       });
   });
+  it('should support table names with IN clauses', () => {
+    const sql = `SELECT * FROM pets WHERE owner_name IN people;`
+    expect(getParsedSql(sql)).to.be.equal('SELECT * FROM "pets" WHERE "owner_name" IN "people"')
+  })
 })


### PR DESCRIPTION
This PR adds support for table-names in IN clauses, e.g.

```
WITH people AS (VALUES ('john'), ('joe')) SELECT * from PETS WHERE owner_name IN people
```